### PR TITLE
Fix require_boost_libs libraries argument in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ include(BoostLib)
 
 # locate/download boost
 SET(Boost_USE_STATIC_LIBS ON)
-require_boost_libs(">= 1.57.0" thread;date_time;filesystem)
+require_boost_libs(">= 1.57.0" "thread;date_time;filesystem")
 
 # set up libtorrent
 set(LIBTORRENT_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/deps/libtorrent)


### PR DESCRIPTION
While trying convert the build for newer version of libtorrent v1.1.1, which has additional dependencies on boost_random, I couldn't get cmake-js and boost-lib to build the boost_random library.

Using quotes around the list of the boost libraries fixed the problem.

This patch isn't required for the module to build currently, it seems the default libraries that get built are enough for libtorrent. So this would be a fix for the future.